### PR TITLE
🔩  Added `vantageScore` function lookup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexbase/ecredit-node-client",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Node.js Client for CRS Credit eCredit API",
   "keywords": [
     "crscreditapi.com",

--- a/src/experian.ts
+++ b/src/experian.ts
@@ -195,4 +195,18 @@ export class ExperianApi {
     }
     return { success: true, report: resp?.payload }
   }
+
+  /*
+   * Simple function to extract the Vantage Score from the Experian Report
+   * and return it - or `undefined` if there's nothing to be found.
+   */
+  vantageScore(rpt: CreditReport): number | undefined {
+    let score
+    const vantage = (rpt?.riskModel ?? [])
+      .find(rm => rm.modelIndicator === 'V4')
+    if (vantage?.score) {
+      score = Number(vantage?.score)
+    }
+    return score
+  }
 }

--- a/tests/basic.ts
+++ b/tests/basic.ts
@@ -22,7 +22,7 @@ import { Ecredit } from '../src/index'
   const one = await client.experian.basic(laurie, { config: 'exp-prequal-vantage4' })
   // console.log('ONE', one)
   if (one.success) {
-    console.log('Success! Pulled the prequal report for test person')
+    console.log(`Success! Pulled the prequal report for test person... Vantage Score: ${client.experian.vantageScore(one?.report!)}`)
   } else {
     console.log('Error! Getting soft Experian pull failed, and the output is:')
     console.log(one)
@@ -32,7 +32,7 @@ import { Ecredit } from '../src/index'
   const two = await client.experian.basic(laurie, { config: 'exp-hard-vantage4' })
   // console.log('TWO', two)
   if (two.success) {
-    console.log('Success! Pulled the hard report for test person')
+    console.log(`Success! Pulled the hard report for test person... Vantage Score: ${client.experian.vantageScore(two?.report!)}`)
   } else {
     console.log('Error! Getting hard Experian pull failed, and the output is:')
     console.log(two)


### PR DESCRIPTION
Since the Experian Credit report's often used number is the Vantage
Score, we made a simple access function to look into the CreditReport
and then extract the Vantage Score from that report. Simple and easy for
beginners.