### PR TITLE
📦  Add TransUnion Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexbase/ecredit-node-client",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Node.js Client for CRS Credit eCredit API",
   "keywords": [
     "crscreditapi.com",

--- a/src/experian.ts
+++ b/src/experian.ts
@@ -238,7 +238,6 @@ export class ExperianApi {
    */
   isFrozen(rpt: CreditReport): boolean {
     let score = false
-    // this needs to wait until we have the data to work with
     const stmt = (rpt?.statement ?? [])
       .find(st => /.* FILE FROZEN .*/.test(st.statementText ?? ''))
     if (stmt?.dateReported) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import path from 'path'
 
 import { AuthenticationApi } from './authentication'
 import { ExperianApi } from './experian'
+import { TransUnionApi } from './transunion'
 
 const ClientVersion = require('../package.json').version
 const PROTOCOL = 'https'
@@ -53,6 +54,7 @@ export class Ecredit {
   password: string
   authentication: AuthenticationApi
   experian: ExperianApi
+  transunion: TransUnionApi
 
   constructor (username: string, password: string, options?: EcreditOptions) {
     this.host = options?.host ?? ECREDIT_HOST
@@ -61,6 +63,7 @@ export class Ecredit {
     // now construct all the specific domain objects
     this.authentication = new AuthenticationApi(this, options)
     this.experian = new ExperianApi(this, options)
+    this.transunion = new TransUnionApi(this, options)
   }
 
   /*

--- a/src/transunion.ts
+++ b/src/transunion.ts
@@ -1,0 +1,277 @@
+import type { Ecredit, EcreditOptions, EcreditError } from './'
+
+export interface CreditReport {
+  fileNumber: string;
+  fileSummary: {
+    fileHitIndicator: string;
+    ssnMatchIndicator: string;
+    consumerStatementIndicator: boolean;
+    market: string;
+    submarket: string;
+    creditDataStatus: {
+      suppressed: boolean;
+      doNotPromote: {
+        indicator: boolean;
+      };
+      freeze: {
+        indicator: boolean;
+      };
+      minor: boolean;
+      disputed: boolean;
+    };
+    inFileSinceDate: Date;
+  };
+  indicative: {
+    names: Name[]
+    addresses: Address[];
+    socialSecurities: {
+      number: string;
+      source: string;
+    }[];
+    dateOfBirths: Date[];
+    ages: any[];
+    phones: any[];
+    employments: Employment[];
+    creditCards: any[];
+    genders: any[];
+    vehicles: any[];
+  };
+  originalInputs: any[];
+  custom: {
+    credit: {
+      trades: Trade[];
+      collections: Collection[];
+      publicRecords: any[];
+      inquiries: Inquiry[];
+    };
+  };
+  addOnProducts: Product[];
+}
+
+export interface Date {
+  value: string;
+  estimatedCentury: boolean;
+  estimatedYear: boolean;
+  estimatedMonth: boolean;
+  estimatedDay: boolean;
+}
+
+export interface Remark {
+  code: string;
+  type: string;
+};
+
+export interface Name {
+  person: {
+    first?: string;
+    middle?: string;
+    last?: string;
+  };
+  source: string;
+}
+
+export interface Address {
+  status: string;
+  qualifier: string;
+  street: {
+    unparseds?: string[];
+    number?: string;
+    name?: string;
+    preDirectional?: string;
+    type?: string;
+  };
+  location: {
+    city: string;
+    state: string;
+    zipCode?: string;
+  };
+  dateReported: Date;
+  source: string;
+};
+
+export interface Employment {
+  employer: {
+    unparsed: string;
+  };
+  occupation: string;
+  dateOnFileSince: Date;
+  dateEffective: Date;
+  source: string;
+};
+
+export interface Trade {
+  subscriber: {
+    industryCode: string;
+    memberCode: string;
+    name: {
+      unparsed: string;
+    };
+  };
+  portfolioType: string;
+  accountNumber: string;
+  dateOpened: Date;
+  dateEffective: Date;
+  currentBalance: string;
+  highCredit: string;
+  accountRating: string;
+  remarks: Remark[];
+  pastDue: string;
+  paymentHistory: {
+    maxDelinquencies: any[];
+  };
+  accountHistories: any[];
+  updateMethod: string;
+  ecoadesignator: string;
+};
+
+export interface Collection {
+  subscriber: {
+    industryCode: string;
+    memberCode: string;
+    name: {
+      unparsed: string;
+    };
+  };
+  portfolioType: string;
+  accountNumber: string;
+  dateOpened: Date;
+  dateEffective: Date;
+  currentBalance: string;
+  original: {
+    creditGrantor: {
+      unparsed: string;
+    };
+    creditorClassification: string;
+    balance: string;
+  };
+  pastDue: string;
+  accountRating: string;
+  remarks: Remark[];
+  updateMethod: string;
+  ecoadesignator: string;
+};
+
+export interface Inquiry {
+  subscriber: {
+    industryCode: string;
+    memberCode: string;
+    inquirySubscriberPrefixCode: string;
+    name: {
+      unparsed: string;
+    };
+  };
+  date: Date;
+  ecoadesignator: string;
+};
+
+export interface Product {
+  code: string;
+  status: string;
+  idMismatchAlerts: {
+    type: string;
+    condition: string;
+    inquiriesInLast60Count: string;
+    addressStatus: string;
+  }[];
+  addressAnalysises: any[];
+  creditorContacts: any[];
+  scoreModel?: {
+    score: {
+      results: string;
+      derogatoryAlert: boolean;
+      fileInquiriesImpactedScore: boolean;
+      factors: {
+        factors: {
+          rank: string;
+          code: string;
+        }[];
+      };
+    };
+    characteristics: any[];
+    messages: any[];
+    statements: any[];
+    consumerStatements: any[];
+    complianceConditions: any[];
+    idMismatchAlerts: any[];
+  };
+};
+
+import { isEmpty } from './'
+
+export class TransUnionApi {
+  client: Ecredit
+
+  constructor(client: Ecredit, _options?: EcreditOptions) {
+    this.client = client
+  }
+
+  /*
+   * Function to take some standard User information and run the Basic
+   * TransUnion Credit Report on the data and return it. This is something
+   * that should be pretty standard. The optional 'config' is there to
+   * indicate what type of TransUnion Credit Report we are looking to obtain.
+   */
+  async basic(data: {
+    firstName: string,
+    middleName?: string,
+    lastName: string,
+    nameSuffix?: string,
+    dob?: string,
+    ssn?: string,
+    phone?: string,
+    street1: string,
+    street2?: string,
+    city: string,
+    state: string,
+    zip: string,
+  }, options?: {
+    config?: string,
+  }): Promise<{
+    success: boolean,
+    report?: CreditReport,
+    error?: EcreditError,
+  }> {
+    let uri = 'transunion/credit-report/basic'
+    // see if we have been given a 'config' to use
+    if (!isEmpty(options?.config)) {
+      uri += `/${options?.config}`
+    }
+    // prep the fields for the the call - if needed
+    if (!isEmpty(data.zip)) {
+      data.zip = data.zip!.replace(/-/g, '')
+    }
+    if (!isEmpty(data.ssn)) {
+      data.ssn = data.ssn!.replace(/-/g, '')
+    }
+    // ...now make the call...
+    const resp = await this.client.fire('POST', uri, undefined, data )
+    if ((resp?.response?.status >= 400) || !isEmpty(resp?.payload?.timestamp)) {
+      return { success: false, error: { ...resp?.payload, type: 'ecredit' } }
+    }
+    return { success: true, report: resp?.payload }
+  }
+
+  /*
+   * Simple function to extract the FICO Score from the Experian Report
+   * and return it - or `undefined` if there's nothing to be found.
+   */
+  ficoScore(rpt: CreditReport): string | number | undefined {
+    let score
+    const fico = (rpt?.addOnProducts ?? [])
+      .find(rm => rm.code === '00W18')
+    if (fico?.scoreModel?.score?.results) {
+      score = Number(fico.scoreModel.score.results)
+    }
+    return score
+  }
+
+  /*
+   * Simple predicate function to look and see if the User's credit has
+   * been 'frozen' so that Credit Reports can't be run against it - for
+   * anti-fraud reasons.
+   */
+  isFrozen(rpt: CreditReport): boolean {
+    const ind = rpt?.fileSummary?.creditDataStatus?.freeze?.indicator
+    return !!ind
+  }
+}

--- a/tests/basic.ts
+++ b/tests/basic.ts
@@ -79,4 +79,26 @@ import { Ecredit } from '../src/index'
     console.log(fiv)
   }
 
+  const zelnino = {
+    firstName: 'ZELNINO',
+    middleName: 'X',
+    lastName: 'WINTER',
+    street1: '760WSPROULRD',
+    city: 'FANTASYISLAND',
+    state: 'IL',
+    zip: '60750',
+    ssn: '666125812'
+  }
+
+  console.log('doing a soft pull from TransUnion for FICO score...')
+  const six = await client.transunion.basic(zelnino, { config: 'tu-prequal-fico9' })
+  // console.log('six', six?.report)
+  if (six.success) {
+    console.log(`Success! Pulled the prequal report for test person... FICO Score: ${client.transunion.ficoScore(six?.report!)}`)
+    console.log(`Success! Pulled the prequal report for test person... Credit Frozen: ${client.transunion.isFrozen(six?.report!)}`)
+  } else {
+    console.log('Error! Getting soft Experian FICO pull failed, and the output is:')
+    console.log(six)
+  }
+
 })()


### PR DESCRIPTION
We needed to have TransUnion suppport for FICO 9 scores, so we added it.
This is not a lot different than the Experian pulls, but it's a
different data structure, and that had to all be written up, and the
helper functions had to be modified.