### PR TITLE
📦  Added publicRecords function on TransUnion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexbase/ecredit-node-client",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Node.js Client for CRS Credit eCredit API",
   "keywords": [
     "crscreditapi.com",

--- a/src/transunion.ts
+++ b/src/transunion.ts
@@ -274,4 +274,42 @@ export class TransUnionApi {
     const ind = rpt?.fileSummary?.creditDataStatus?.freeze?.indicator
     return !!ind
   }
+
+  /*
+   * Function to look at the public records of the TransUnion data and
+   * return a string[] of all the records - mostly Bankruptcies - that
+   * are on this credit report.
+   */
+  publicRecords(rpt: CreditReport): string[] {
+    let ans = [] as string[]
+    const recs = rpt?.custom?.credit?.publicRecords ?? []
+    for (const r of recs) {
+      const code = this.publicCodes[r?.type] as string
+      if (code) {
+        ans.push(code)
+      }
+    }
+    return ans
+  }
+
+  // ...and these are the codes for publicRecords
+  publicCodes = {
+    'CP': 'Child support',
+    '1D': 'Chapter 11 bankruptcy dismissed/closed',
+    '1F': 'Chapter 11 bankruptcy filing',
+    '1V': 'Chapter 11 bankruptcy voluntary dismissal',
+    '1X': 'Chapter 11 bankruptcy discharged',
+    '2D': 'Chapter 12 bankruptcy dismissed/closed',
+    '2F': 'Chapter 12 bankruptcy filing',
+    '2V': 'Chapter 12 bankruptcy voluntary dismissal',
+    '2X': 'Chapter 12 bankruptcy discharged',
+    '3D': 'Chapter 13 bankruptcy dismissed/closed',
+    '3F': 'Chapter 13 bankruptcy filing',
+    '3V': 'Chapter 13 bankruptcy voluntary dismissal',
+    '3X': 'Chapter 13 bankruptcy discharged',
+    '7D': 'Chapter 7 bankruptcy dismissed/closed',
+    '7F': 'Chapter 7 bankruptcy filing',
+    '7V': 'Chapter 7 bankruptcy voluntary dismissal',
+    '7X': 'Chapter 7 bankruptcy discharged',
+  } as { [index: string] : string }
 }

--- a/tests/basic.ts
+++ b/tests/basic.ts
@@ -92,13 +92,48 @@ import { Ecredit } from '../src/index'
 
   console.log('doing a soft pull from TransUnion for FICO score...')
   const six = await client.transunion.basic(zelnino, { config: 'tu-prequal-fico9' })
-  // console.log('six', six?.report)
+  // console.log('SIX', six?.report)
   if (six.success) {
     console.log(`Success! Pulled the prequal report for test person... FICO Score: ${client.transunion.ficoScore(six?.report!)}`)
     console.log(`Success! Pulled the prequal report for test person... Credit Frozen: ${client.transunion.isFrozen(six?.report!)}`)
   } else {
     console.log('Error! Getting soft Experian FICO pull failed, and the output is:')
     console.log(six)
+  }
+
+  console.log('doing a hard pull from TransUnion for FICO score...')
+  const sev = await client.transunion.basic(zelnino, { config: 'tu-hard-fico9' })
+  // console.log('SEV', sev?.report)
+  if (sev.success) {
+    console.log(`Success! Pulled the prequal report for test person... FICO Score: ${client.transunion.ficoScore(sev?.report!)}`)
+    console.log(`Success! Pulled the prequal report for test person... Credit Frozen: ${client.transunion.isFrozen(sev?.report!)}`)
+    console.log('Issues', client.transunion.publicRecords(sev?.report!))
+  } else {
+    console.log('Error! Getting soft Experian FICO pull failed, and the output is:')
+    console.log(sev)
+  }
+
+  const taron = {
+    firstName: 'Taron',
+    middleName: '',
+    lastName: 'Mason',
+    street1: '204 WINN RD',
+    city: 'Lee',
+    state: 'ME',
+    zip: '04455-4216',
+    ssn:  '666319724',
+  }
+
+  console.log('doing a soft pull from TransUnion for FICO score...')
+  const eig = await client.transunion.basic(taron, { config: 'tu-hard-fico9' })
+  // console.log('EIG', eig?.report)
+  if (eig.success) {
+    console.log(`Success! Pulled the prequal report for test person... FICO Score: ${client.transunion.ficoScore(eig?.report!)}`)
+    console.log(`Success! Pulled the prequal report for test person... Credit Frozen: ${client.transunion.isFrozen(eig?.report!)}`)
+    console.log('Issues', client.transunion.publicRecords(eig?.report!))
+  } else {
+    console.log('Error! Getting soft Experian FICO pull failed, and the output is:')
+    console.log(eig)
   }
 
 })()


### PR DESCRIPTION
We needed to be able to easily get the Bankruptcies for a credit run,
and this was the way. We got a test user with issues, and then ran them
and decoded the 'type' values, and return them. This should work just
fine.