### PR TITLE
🔩  Add new Auth Expiration Error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flexbase/ecredit-node-client",
-  "version": "0.1.0",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@flexbase/ecredit-node-client",
-      "version": "0.1.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@types/formdata": "^0.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexbase/ecredit-node-client",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Node.js Client for CRS Credit eCredit API",
   "keywords": [
     "crscreditapi.com",

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,7 @@ export class Ecredit {
         const payload = await response?.json()
         // check for an invalid token from the service
         if (response.status == 401 && Array.isArray(payload?.messages) &&
-            payload?.messages.includes('User Token Invalid')) {
+            ['User Token Invalid', 'User Token Expired'].includes(payload?.messages)) {
           const auth = await this.authentication.resetToken()
           if (!auth?.success) {
             return { response: { ...response, payload: auth } }

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,8 @@ export class Ecredit {
         const payload = await response?.json()
         // check for an invalid token from the service
         if (response.status == 401 && Array.isArray(payload?.messages) &&
-            ['User Token Invalid', 'User Token Expired'].includes(payload?.messages)) {
+            (payload?.messages.includes('User Token Invalid') ||
+             payload?.messages.includes('User Token Expired'))) {
           const auth = await this.authentication.resetToken()
           if (!auth?.success) {
             return { response: { ...response, payload: auth } }


### PR DESCRIPTION
CRS added a new User Auth token expiration message, and it makes more sense to include it here in the retries because that's what this is all about, than to make the clients understand this and retry.