### PR TITLE
⚙️  Pulled `requestid` from Headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flexbase/ecredit-node-client",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@flexbase/ecredit-node-client",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@types/formdata": "^0.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexbase/ecredit-node-client",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Node.js Client for CRS Credit eCredit API",
   "keywords": [
     "crscreditapi.com",

--- a/src/equifax.ts
+++ b/src/equifax.ts
@@ -411,6 +411,7 @@ export class EquifaxApi {
     config?: string,
   }): Promise<{
     success: boolean,
+    requestId: string,
     report?: CreditReport,
     error?: EcreditError,
   }> {
@@ -432,9 +433,17 @@ export class EquifaxApi {
     // ...now make the call...
     const resp = await this.client.fire('POST', uri, undefined, data )
     if ((resp?.response?.status >= 400) || !isEmpty(resp?.payload?.timestamp)) {
-      return { success: false, error: { ...resp?.payload, type: 'ecredit' } }
+      return {
+        success: false,
+        requestId: resp?.response?.headers.get('requestid'),
+        error: { ...resp?.payload, type: 'ecredit' }
+      }
     }
-    return { success: true, report: resp?.payload }
+    return {
+      success: true,
+      requestId: resp?.response?.headers.get('requestid'),
+      report: resp?.payload
+    }
   }
 
   /*

--- a/src/experian.ts
+++ b/src/experian.ts
@@ -180,6 +180,7 @@ export class ExperianApi {
     config?: string,
   }): Promise<{
     success: boolean,
+    requestId: string,
     report?: CreditReport,
     error?: EcreditError,
   }> {
@@ -198,9 +199,17 @@ export class ExperianApi {
     // ...now make the call...
     const resp = await this.client.fire('POST', uri, undefined, data )
     if ((resp?.response?.status >= 400) || !isEmpty(resp?.payload?.timestamp)) {
-      return { success: false, error: { ...resp?.payload, type: 'ecredit' } }
+      return {
+        success: false,
+        requestId: resp?.response?.headers.get('requestid'),
+        error: { ...resp?.payload, type: 'ecredit' }
+      }
     }
-    return { success: true, report: resp?.payload }
+    return {
+      success: true,
+      requestId: resp?.response?.headers.get('requestid'),
+      report: resp?.payload
+    }
   }
 
   /*

--- a/src/transunion.ts
+++ b/src/transunion.ts
@@ -228,6 +228,7 @@ export class TransUnionApi {
     config?: string,
   }): Promise<{
     success: boolean,
+    requestId: string,
     report?: CreditReport,
     error?: EcreditError,
   }> {
@@ -246,9 +247,17 @@ export class TransUnionApi {
     // ...now make the call...
     const resp = await this.client.fire('POST', uri, undefined, data )
     if ((resp?.response?.status >= 400) || !isEmpty(resp?.payload?.timestamp)) {
-      return { success: false, error: { ...resp?.payload, type: 'ecredit' } }
+      return {
+        success: false,
+        requestId: resp?.response?.headers.get('requestid'),
+        error: { ...resp?.payload, type: 'ecredit' }
+      }
     }
-    return { success: true, report: resp?.payload }
+    return {
+      success: true,
+      requestId: resp?.response?.headers.get('requestid'),
+      report: resp?.payload
+    }
   }
 
   /*


### PR DESCRIPTION
The CRS Credit support guys would like to know what the `reauestId` is on the calls - so they can track them down, and it's returned in the headers, so we now extract that, and we return it as a top-level value in the responses. This will make it so much easier to track.