### PR TITLE
Feature/fbt 949 extend ecredit node client to handle users/logs endpoint

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,3 @@
+ECREDIT_USERNAME=''
+ECREDIT_PASSWORD=''
+ECREDIT_HOST='api-sandbox.stitchcredit.com/api'

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ with CRS Credit:
 
 * `ECREDIT_USERNAME` - this is the CRS Credit generated "username".
 * `ECREDIT_PASSWORD` - this is the CRS Credit "password".
+* `ECREDIT_HOST` - this is the CRS Host "host".
 
 ### Testing
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { AuthenticationApi } from './authentication'
 import { ExperianApi } from './experian'
 import { TransUnionApi } from './transunion'
 import { EquifaxApi } from './equifax'
+import { UserApi } from './user'
 
 const ClientVersion = require('../package.json').version
 const PROTOCOL = 'https'
@@ -57,6 +58,7 @@ export class Ecredit {
   experian: ExperianApi
   transunion: TransUnionApi
   equifax: EquifaxApi
+  user: UserApi
 
   constructor (username: string, password: string, options?: EcreditOptions) {
     this.host = options?.host ?? ECREDIT_HOST
@@ -67,6 +69,7 @@ export class Ecredit {
     this.experian = new ExperianApi(this, options)
     this.transunion = new TransUnionApi(this, options)
     this.equifax = new EquifaxApi(this, options)
+    this.user = new UserApi(this, options)
   }
 
   /*

--- a/src/user.ts
+++ b/src/user.ts
@@ -1,0 +1,107 @@
+import { Ecredit, EcreditOptions, EcreditError, isEmpty } from './'
+
+/*
+No public API docs available. Example response from a /users/logs call:
+
+{
+   "hasMore":true,
+   "count":40,
+   "content":[
+      {
+         "id":"a22b7541-fa34-409a-a43d-1695a146f49d",
+         "type":"EFX",
+         "encryptionKey":"4b5404b0-6d9c-4583-9ff5-d04d1ca0a2a6",
+         "ip":1806880623,
+         "ipAddress":"107.178.207.111",
+         "detail":"Individual Report 1",
+         "createdAt":"2023-06-08T23:41:38.306+00:00",
+         "status":"SUCCESS",
+         "method":"POST",
+         "description":"Credit Report",
+         "product":"Equifax",
+         "url":"/api/equifax/credit-report/efx-business-principal-fico9",
+         "responseCode":"200",
+         "userId":"4bd8352b-b659-4d2f-9814-d0d2c5c59a8b",
+         "clientEmail":"fadi@flexbase.app",
+         "clientName":"Flexbase",
+         "userConfigId":"167067ab-b695-440d-a54c-0946a1d576de",
+         "userConfigDesc":"efx-business-principal-fico9 not configured yet"
+      },
+      ...
+    ]
+}
+*/
+export interface UserReport {
+    hasMore: boolean
+    count: number
+    content: UserLog[]
+}
+
+export interface UserLog {
+    id: string
+    type: string
+    encryptionKey: string
+    ip: number
+    ipAddress: string
+    detail: string
+    createdAt: string
+    status: string
+    method: string
+    description: string
+    product: string
+    url: string
+    responseCode: string
+    userId: string
+    clientEmail: string
+    clientName: string
+    userConfigId: string
+    userConfigDesc: string
+}
+
+
+export class UserApi {
+  client: Ecredit
+  
+  constructor(client: Ecredit, _options?: EcreditOptions) {
+    this.client = client
+  }
+
+  /*
+   * Function optionally takes page number and returns an array of logs for requests CRS has recorded
+   * for the user who generated the auth credentials.
+   */
+  async basic(data: {
+    page?: number,
+  },
+  options?: {
+    config?: string,
+  }): Promise<{
+    success: boolean,
+    requestId: string,
+    report?: UserReport,
+    error?: EcreditError,
+  }> {
+    const _page = data.page ?? 0
+
+    let uri = `user/logs?page=${_page}`
+    // see if we have been given a 'config' to use
+    if (!isEmpty(options?.config)) {
+      uri += `/${options?.config}`
+    }
+
+    // ...now make the call...
+    const resp = await this.client.fire('GET', uri, undefined, data )
+    if ((resp?.response?.status >= 400) || !isEmpty(resp?.payload?.timestamp)) {
+      return {
+        success: false,
+        requestId: resp?.response?.headers.get('requestid'),
+        error: { ...resp?.payload, type: 'user' }
+      }
+    }
+    return {
+      success: true,
+      requestId: resp?.response?.headers.get('requestid'),
+      report: resp?.payload
+    }
+  }
+}

--- a/tests/basic.ts
+++ b/tests/basic.ts
@@ -213,4 +213,12 @@ import { Ecredit } from '../src/index'
     console.log(ele)
   }
 
+  console.log('pulling the first page of user logs...')
+  const _logs = await client.user.basic({ page: 0 })
+  if (_logs.success) {
+    console.log(`Sucess! Pulled the logs for the authorized account... Count is: ${_logs?.report}`)
+  } else {
+    console.log('Error! Getting the logs for the authorized account failed, and the output is:')
+    console.log(_logs)
+  }
 })()

--- a/tests/basic.ts
+++ b/tests/basic.ts
@@ -216,7 +216,7 @@ import { Ecredit } from '../src/index'
   console.log('pulling the first page of user logs...')
   const _logs = await client.user.basic({ page: 0 })
   if (_logs.success) {
-    console.log(`Sucess! Pulled the logs for the authorized account... Count is: ${_logs?.report}`)
+    console.log(`Sucess! Pulled the logs for the authorized account... Count is: ${_logs?.report?.count}`)
   } else {
     console.log('Error! Getting the logs for the authorized account failed, and the output is:')
     console.log(_logs)

--- a/tests/check-auth.ts
+++ b/tests/check-auth.ts
@@ -12,6 +12,7 @@ import { Ecredit } from '../src/index'
   // console.log('ONE', one)
   if (one.success) {
     console.log('Success!')
+    console.log(one)
   } else {
     console.log('Error! I was not able to get a valid auth token')
     console.log(one)
@@ -21,7 +22,7 @@ import { Ecredit } from '../src/index'
   if (client.authentication.token) {
     console.log('Success!')
   } else {
-    console.log('Error! I was not able to veify the new auth token')
+    console.log('Error! I was not able to verify the new auth token')
     console.log(client.authentication.token)
   }
 

--- a/tests/check-auth.ts
+++ b/tests/check-auth.ts
@@ -12,7 +12,6 @@ import { Ecredit } from '../src/index'
   // console.log('ONE', one)
   if (one.success) {
     console.log('Success!')
-    console.log(one)
   } else {
     console.log('Error! I was not able to get a valid auth token')
     console.log(one)


### PR DESCRIPTION
# Just a draft!

@drbobbeaty we discussed everything returning as undefined. I copied the credentials verbatim so I am thinking it's a local environment issue on my side.
```
node --version
v20.0.0
```

The auth test is failing because the authentication token isn't sticking:
```
➜  ecredit-node-client git:(feature/fbt-949-extend-ecredit-node-client-to-handle-userslogs-endpoint) npm run ts tests/check-auth.ts

> @flexbase/ecredit-node-client@0.12.0 ts
> ts-node -r dotenv/config tests/check-auth.ts

attempting to get an authentication token...
Success!
checking that the authentication token stuck...
Error! I was not able to verify the new auth token
undefined
attempting to reset for a new authentication token...
Success!
```

All of the original basic tests return successful, but the values are undefined: 
```
➜  ecredit-node-client git:(feature/fbt-949-extend-ecredit-node-client-to-handle-userslogs-endpoint) npm run ts tests/basic.ts

> @flexbase/ecredit-node-client@0.12.0 ts
> ts-node -r dotenv/config tests/basic.ts

doing a soft pull from Experian for Vantage score...
Success! Pulled the prequal report for test person... Vantage Score: undefined
doing a hard pull from Experian Vantage score...
Success! Pulled the hard report for test person... Vantage Score: undefined
doing a soft pull from Experian for FICO score...
Success! Pulled the prequal report for test person... FICO Score: undefined
doing a hard pull from Experian for FICO score...
Success! Pulled the hard report for test person... FICO Score: undefined
doing a soft pull from Experian for FICO score on a frozen account...
```

