### PR TITLE
⚙️ Add `hitCode()` function for report

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flexbase/ecredit-node-client",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@flexbase/ecredit-node-client",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@types/formdata": "^0.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexbase/ecredit-node-client",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Node.js Client for CRS Credit eCredit API",
   "keywords": [
     "crscreditapi.com",

--- a/src/equifax.ts
+++ b/src/equifax.ts
@@ -435,13 +435,13 @@ export class EquifaxApi {
     if ((resp?.response?.status >= 400) || !isEmpty(resp?.payload?.timestamp)) {
       return {
         success: false,
-        requestId: resp?.response?.headers.get('requestid'),
+        requestId: resp?.response?.headers?.get('requestid'),
         error: { ...resp?.payload, type: 'ecredit' }
       }
     }
     return {
       success: true,
-      requestId: resp?.response?.headers.get('requestid'),
+      requestId: resp?.response?.headers?.get('requestid'),
       report: resp?.payload
     }
   }
@@ -543,6 +543,20 @@ export class EquifaxApi {
       .find(rm => rm.modelNumber === '05206')
     for (const r of (fico?.reasons ?? [])) {
       ans.push(ficoReasons[Number(r.code)])
+    }
+    return ans
+  }
+
+  /*
+   * Function to return the Hit Code from Equifax and CRS that
+   * can be very useful if it's *not* 'Hit' - so it is useful
+   * to check this by the caller to make sure things went well.
+   */
+  hitCode(rpt: CreditReport): string | undefined {
+    let ans
+    const hit = rpt?.data?.hitCode
+    if (hit?.description) {
+      ans = hit.description
     }
     return ans
   }


### PR DESCRIPTION
There will be times that the `hitCode` will be very useful, and in those cases, it's nice to have a simple convenience method to pull this up.